### PR TITLE
According to cssProp definition, the assertion will fail if only passing...

### DIFF
--- a/tests/csstransforms-standard/test.js
+++ b/tests/csstransforms-standard/test.js
@@ -1,17 +1,17 @@
 test("CSS Transforms (2d), standard", function() {
   var elem = document.createElement("div");
 
-  assert( H.test.cssProp( elem ), "transform, standard supported" );
+  assert( H.test.cssProp( elem, "transform" ), "transform, standard supported" );
 });
 
 test("CSS Transforms (3d), standard", function() {
   var elem = document.createElement("div");
 
-  assert( H.test.cssProp( elem ), "transform-3d, standard supported" );
+  assert( H.test.cssProp( elem, "transform-3d" ), "transform-3d, standard supported" );
 });
 
 test("CSS Transforms Perspective (3d), standard", function() {
   var elem = document.createElement("div");
 
-  assert( H.test.cssProp( elem ), "perspective, standard supported" );
+  assert( H.test.cssProp( elem, "perspective" ), "perspective, standard supported" );
 });


### PR DESCRIPTION
... in the first parameter and leaving other parameters undefined.
