### PR TITLE
Use XHR to download web fonts

### DIFF
--- a/tests/cssfont/fontface.css
+++ b/tests/cssfont/fontface.css
@@ -1,7 +1,0 @@
-@font-face {
-  font-family: 'GothicCustom'; 
-  src: url(LeagueGothic.eot); 
-  src: url(LeagueGothic.woff) format('woff'),      
-       url(LeagueGothic.otf) format('opentype'),      
-       url(LeagueGothic.svg) format('svg'); 
-}

--- a/tests/cssfont/fontface.css
+++ b/tests/cssfont/fontface.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'GothicCustom'; 
+  src: url(LeagueGothic.eot); 
+  src: url(LeagueGothic.woff) format('woff'),      
+       url(LeagueGothic.otf) format('opentype'),      
+       url(LeagueGothic.svg) format('svg'); 
+}

--- a/tests/cssfont/iframe.html
+++ b/tests/cssfont/iframe.html
@@ -7,33 +7,50 @@
 
 <script>
 
-  var doc = document, width = null;
-  var fixture = doc.getElementById("inference");
-  var clone = fixture.cloneNode(true);
-  var fake = fixture.cloneNode(true);
+  path = "/tests/cssfont/"
+  
+  function webfont_test() {
+    var head, fixture, clone, fake, styles, style,
+        doc = document,
+        rule = [
+          "@font-face { ",
+          "font-family: 'GothicCustom'; ",
+          "src: url(" + path + "LeagueGothic.eot); ",
+          "src: url(" + path + "LeagueGothic.woff) format('woff'), ",
+          "     url(" + path + "LeagueGothic.otf) format('opentype'), ",
+          "     url(" + path + "LeagueGothic.svg) format('svg'); }"
+        ].join(""),
+        width = null,
+        styleNode = doc.createElement("style");
 
-  doc.body.appendChild( clone );
-  doc.body.appendChild( fake );
 
-  clone.style.cssText += "font-family: GothicCustom;";
-  fake.style.cssText += "font-family: OHHAI!!!;";
+    styleNode.id = "csseototf";
+    styleNode.innerText = rule;
+    doc.head.appendChild( styleNode );
 
-  // Use Google WebFont Loader to load fonts
-  // https://developers.google.com/webfonts/docs/webfont_loader
-  WebFontConfig = {
-    custom: { families: ['GothicCustom', 'OHHAI!!!'], 
-              urls: ['fontface.css']
-    },
-    active: function() {
+    fixture = doc.getElementById("inference");
+
+
+    clone = fixture.cloneNode(true);
+    fake = fixture.cloneNode(true);
+
+    doc.body.appendChild( clone );
+    doc.body.appendChild( fake );
+
+    clone.style.cssText += "font-family: GothicCustom;";
+    fake.style.cssText += "font-family: OHHAI!!!;";
+
+    setTimeout(function() {
       var orig = parseInt( doc.defaultView.getComputedStyle( fixture ).getPropertyValue("width"), 10 ),
           font = parseInt( doc.defaultView.getComputedStyle( clone ).getPropertyValue("width"), 10 ),
           control = parseInt( doc.defaultView.getComputedStyle( fake ).getPropertyValue("width"), 10 );
+
 
       // The font we have chosen to use should be narrower then the default font
       // of any given UA. This is presumptuous, but pretty close for now.
       // TODO: Refined control over the default/starting font
       //
-      
+
       // IE9Mobile does not support arbitrary object messages,
       // serialize first
       top.postMessage(JSON.stringify({
@@ -49,18 +66,29 @@
           }
         ]
       }), "*");
-    }
-  };
+    }, 100);
+  }
 
-  (function() {
-    var wf = document.createElement('script');
-    wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
-        '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-    wf.type = 'text/javascript';
-    wf.async = 'true';
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(wf, s);
-  })();
+  var font_array = new Array(path + "LeagueGothic.eot", 
+                             path + "LeagueGothic.woff", 
+                             path + "LeagueGothic.otf");
+  fonts_to_download = font_array.length;
+
+  for (var i=0; i<font_array.length; i++) {
+    var req = new XMLHttpRequest();
+    (function(r) {
+      r.onreadystatechange = function(event) {
+        if (r.readyState == 4 && r.status == 200) {
+          fonts_to_download = fonts_to_download - 1;
+          if (fonts_to_download == 0) {
+            webfont_test();
+          }
+        }
+      };
+      r.open("GET", font_array[i], true);
+      r.send();
+    })(req);
+  }
 
 </script>
 </body>

--- a/tests/cssfont/iframe.html
+++ b/tests/cssfont/iframe.html
@@ -18,8 +18,10 @@
   clone.style.cssText += "font-family: GothicCustom;";
   fake.style.cssText += "font-family: OHHAI!!!;";
 
+  // Use Google WebFont Loader to load fonts
+  // https://developers.google.com/webfonts/docs/webfont_loader
   WebFontConfig = {
-    custom: { families: ['GothicCustom'], 
+    custom: { families: ['GothicCustom', 'OHHAI!!!'], 
               urls: ['fontface.css']
     },
     active: function() {

--- a/tests/cssfont/iframe.html
+++ b/tests/cssfont/iframe.html
@@ -7,31 +7,10 @@
 
 <script>
 
-
-  var head, fixture, clone, fake, styles, style,
-      doc = document,
-      path = "/tests/cssfont/",
-      rule = [
-        "@font-face { ",
-        "font-family: 'GothicCustom'; ",
-        "src: url(" + path + "LeagueGothic.eot); ",
-        "src: url(" + path + "LeagueGothic.woff) format('woff'), ",
-        "     url(" + path + "LeagueGothic.otf) format('opentype'), ",
-        "     url(" + path + "LeagueGothic.svg) format('svg'); }"
-      ].join(""),
-      width = null,
-      styleNode = doc.createElement("style");
-
-
-  styleNode.id = "csseototf";
-  styleNode.innerText = rule;
-  doc.head.appendChild( styleNode );
-
-  fixture = doc.getElementById("inference");
-
-
-  clone = fixture.cloneNode(true);
-  fake = fixture.cloneNode(true);
+  var doc = document, width = null;
+  var fixture = doc.getElementById("inference");
+  var clone = fixture.cloneNode(true);
+  var fake = fixture.cloneNode(true);
 
   doc.body.appendChild( clone );
   doc.body.appendChild( fake );
@@ -39,33 +18,47 @@
   clone.style.cssText += "font-family: GothicCustom;";
   fake.style.cssText += "font-family: OHHAI!!!;";
 
-  setTimeout(function() {
-    var orig = parseInt( doc.defaultView.getComputedStyle( fixture ).getPropertyValue("width"), 10 ),
-        font = parseInt( doc.defaultView.getComputedStyle( clone ).getPropertyValue("width"), 10 ),
-        control = parseInt( doc.defaultView.getComputedStyle( fake ).getPropertyValue("width"), 10 );
+  WebFontConfig = {
+    custom: { families: ['GothicCustom'], 
+              urls: ['fontface.css']
+    },
+    active: function() {
+      var orig = parseInt( doc.defaultView.getComputedStyle( fixture ).getPropertyValue("width"), 10 ),
+          font = parseInt( doc.defaultView.getComputedStyle( clone ).getPropertyValue("width"), 10 ),
+          control = parseInt( doc.defaultView.getComputedStyle( fake ).getPropertyValue("width"), 10 );
 
+      // The font we have chosen to use should be narrower then the default font
+      // of any given UA. This is presumptuous, but pretty close for now.
+      // TODO: Refined control over the default/starting font
+      //
+      
+      // IE9Mobile does not support arbitrary object messages,
+      // serialize first
+      top.postMessage(JSON.stringify({
+        which: "practical",
+        results: [
+          {
+            desc: "Custom font supported",
+            result: font !== orig
+          },
+          {
+            desc: "Custom font distinguished from non-custom",
+            result: font !== control
+          }
+        ]
+      }), "*");
+    }
+  };
 
-    // The font we have chosen to use should be narrower then the default font
-    // of any given UA. This is presumptuous, but pretty close for now.
-    // TODO: Refined control over the default/starting font
-    //
-
-    // IE9Mobile does not support arbitrary object messages,
-    // serialize first
-    top.postMessage(JSON.stringify({
-      which: "practical",
-      results: [
-        {
-          desc: "Custom font supported",
-          result: font !== orig
-        },
-        {
-          desc: "Custom font distinguished from non-custom",
-          result: font !== control
-        }
-      ]
-    }), "*");
-  }, 100);
+  (function() {
+    var wf = document.createElement('script');
+    wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+        '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+    wf.type = 'text/javascript';
+    wf.async = 'true';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(wf, s);
+  })();
 
 </script>
 </body>


### PR DESCRIPTION
Use XHR to download web fonts in advance before applying them. Only one file change: tests/cssfont/iframe.html
Btw: I tested Google Webfont Loader, but seems not work.
