### PR TITLE
fix css font face rule

### DIFF
--- a/tests/cssfont/iframe.html
+++ b/tests/cssfont/iframe.html
@@ -100,8 +100,11 @@
     // Loop over types and construct src rule entries
     while ( this.types.length ) {
       src = this.types.shift();
+      if (src.type === "eot" || src.type === "otf") {
+        rules.push("src: ");
+      }
       rules.push(
-        "src: url(" + file + src.type + ") " +
+        "url(" + file + src.type + ") " +
         ( src.format ? "format('" + src.format + "');" : ";" )
       );
     }


### PR DESCRIPTION
According to font face rule described here: http://www.w3.org/TR/css3-fonts/#font-face-rule
Rule with src descriptor has override behavior which means only the last rule will succeed.
Therefore, in the test, the rule shall construct like the one below (with the first rule for IE compatibility reason and having one "src" prefix for the rest)

@font-face { font-family: 'GothicCustom'; 
src: url(/tests/cssfont/LeagueGothic.eot) ;
src: url(/tests/cssfont/LeagueGothic.otf) format('opentype');
     url(/tests/cssfont/LeagueGothic.svg) format('svg');
     url(/tests/cssfont/LeagueGothic.woff) format('woff');
}
