### PR TITLE
Fixed the Canvas 3d, standard (WebGL) test

### DIFF
--- a/tests/canvas-3d-standard/test.js
+++ b/tests/canvas-3d-standard/test.js
@@ -1,20 +1,3 @@
 test("Canvas 3D Context, standard", function() {
-  var canvas = document.createElement("canvas"),
-      contexts = [
-        "3d", "webgl", "experimental-webgl",
-        "moz-webgl", "webkit-3d", "opera-3d", "ms-webgl", "ms-3d"
-      ],
-      which,
-      context;
-
-  while ( contexts.length ) {
-    which = contexts.pop();
-    context = canvas.getContext( which );
-
-    if ( context ) {
-      break;
-    }
-  }
-
-  assert( which === "webgl", "webgl standard, supported" );
+  assert( document.createElement("canvas").getContext("webgl"), "webgl standard, supported" );
 });


### PR DESCRIPTION
There were multiple issues with the original test -
- It was trying to create contexts non standard names.
- The order of the context names to test was reversed (non standard context names would make the browser fail the test, even if it does support the standard context name).

The new test simple tests for the context creation of a context bearing the "webgl" name (which is the standard name).

Desktop Chrome failed this test for no reason. It supports the standard version.
