### PR TITLE
fixed fullscreenElement false positive

### DIFF
--- a/tests/fullscreen/test.js
+++ b/tests/fullscreen/test.js
@@ -10,7 +10,7 @@ test("FullScreen", function() {
 
 
 test("FullScreen document", function() {
-  var fullscreenElement = H.get.domProp( document, "fullscreenElement", true ) !== undefined,
+  var fullscreenElement = H.get.domProp( document, "fullscreenElement", true ) !== false,
       fullscreenEnabled = H.API( document, "fullscreenEnabled", true ),
       exitFullscreen = H.API( document, "exitFullscreen", true );
 


### PR DESCRIPTION
Sorry for it. H.get.domProp returns false when it couldn't find the attribute, which is a bit odd to me. Anyway fullscreenElement attribute always should not have a Boolean value.
