### PR TITLE
instanceof HTMLUnknownElement

### DIFF
--- a/tests/html5/test.js
+++ b/tests/html5/test.js
@@ -20,7 +20,7 @@
       var fixture = document.getElementById("html5"),
           node = fixture.querySelector( name );
 
-      assert( node instanceof HTMLElement, name + " instanceof HTMLElement" );
+      assert( !(node instanceof HTMLUnknownElement), name + " instanceof HTMLUnknownElement is false" );
       assert( node.outerHTML !== "<:" + name + "></:" + name + ">", name + " node created" );
     });
 


### PR DESCRIPTION
I think current HTML5 Layout test is not so proper when document.createElement always returns HTMLElement. 

```
document.createElement('abc') instanceof HTMLElement
```

returns 'true.'
Thus, I fixed it by checking whether it is 'HTMLUnknownElement'
